### PR TITLE
Full observability stack for the sensor system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # Problem no. SIH25001
+
+## Sensors (Arduino, Firebase, Prometheus)
+
+- Python under `sensors/` reads Arduino DHT11 and can push to Firebase Realtime DB.
+- Flask web endpoint (`sensors/web_endpoint.py`) exposes:
+  - `GET /sensor/current` current reading
+  - `POST /sensor/send-to-firebase` push current reading to Firebase
+  - `GET /metrics` Prometheus metrics (temperature, humidity, last read timestamps, counters)
+
+Environment variables:
+
+```
+FIREBASE_DATABASE_URL=https://<your-db>.firebaseio.com
+FIREBASE_CREDENTIALS_FILE=service_key.json
+SERIAL_PORT=/dev/cu.usbmodem1101
+```
+
+Install deps and run exporter:
+
+```bash
+cd sensors
+./venv/bin/pip install -r requirements.txt
+./venv/bin/python web_endpoint.py
+```
+
+## Observability Stack (Prometheus + Grafana)
+
+Local stack via Docker Compose with provisioning.
+
+```bash
+docker compose up -d
+# Prometheus: http://localhost:9090
+# Grafana:    http://localhost:3001 (anonymous viewer enabled)
+```
+
+Prometheus scrapes `http://host.docker.internal:5001/metrics` by default.
+Grafana is preloaded with dashboard `Sensor Overview`.
+
+## Frontend (Next.js)
+
+- Dashboard embeds Grafana (`/dashboard`), configurable via env var:
+
+```
+NEXT_PUBLIC_GRAFANA_EMBED_URL=http://localhost:3001/dashboards
+```
+
+If not set, it defaults to `http://localhost:3001/`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.8"
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    container_name: grafana
+    restart: unless-stopped
+    ports:
+      - "3001:3000"
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+      - GF_SECURITY_ALLOW_EMBEDDING=true
+      - GF_USERS_DEFAULT_THEME=light
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+
+

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import FiltersBar, { type Filters } from "@/components/dashboard/FiltersBar";
 import ReportsList from "@/components/dashboard/ReportsList";
 import QualityGauge from "@/components/widgets/QualityGauge";
+import GrafanaEmbed from "@/components/widgets/GrafanaEmbed";
 
 const fetcher = (url: string) =>
   fetch(url, { cache: "no-store" }).then((r) => r.json());
@@ -66,12 +67,8 @@ export default function DashboardPage() {
       </section>
 
       <section className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-6">
-        <div className="lg:col-span-2 rounded-2xl bg-gradient-to-br from-sky-50 to-emerald-50 dark:from-white/5 dark:to-white/0 backdrop-blur border border-slate-200/60 dark:border-white/10 shadow-sm p-6">
-          <h3 className="text-sm font-medium">Northeast India — Overview</h3>
-          <p className="text-xs text-slate-600 dark:text-slate-400 mt-1">
-            Interactive map removed for performance. Data remains available via
-            counters and reports.
-          </p>
+        <div className="lg:col-span-2">
+          <GrafanaEmbed title="Sensor Overview (Grafana)" />
         </div>
         <div className="rounded-2xl bg-white/70 dark:bg-white/5 backdrop-blur border border-slate-200/60 dark:border-white/10 shadow-sm p-4">
           <h3 className="text-sm font-medium">Water Quality</h3>

--- a/frontend/src/components/widgets/GrafanaEmbed.tsx
+++ b/frontend/src/components/widgets/GrafanaEmbed.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React from "react";
+
+type GrafanaEmbedProps = {
+  src?: string;
+  title?: string;
+  height?: number | string;
+};
+
+export default function GrafanaEmbed({
+  src,
+  title = "Sensor Overview (Grafana)",
+  height = 520,
+}: GrafanaEmbedProps) {
+  const embedSrc =
+    src ||
+    process.env.NEXT_PUBLIC_GRAFANA_EMBED_URL ||
+    "http://localhost:3001/d/sensor-overview";
+
+  return (
+    <div className="rounded-2xl bg-white/70 dark:bg-white/5 backdrop-blur border border-slate-200/60 dark:border-white/10 shadow-sm p-4">
+      <h3 className="text-sm font-medium mb-2">{title}</h3>
+      <div className="w-full overflow-hidden rounded-xl border border-slate-200/60 dark:border-white/10">
+        <iframe
+          src={embedSrc}
+          title={title}
+          style={{ width: "100%", height: typeof height === "number" ? `${height}px` : height }}
+          frameBorder="0"
+          allowFullScreen
+        />
+      </div>
+      <div className="text-xs text-slate-500 dark:text-slate-400 mt-2">
+        Grafana is embedded. Configure NEXT_PUBLIC_GRAFANA_EMBED_URL for a specific dashboard.
+      </div>
+    </div>
+  );
+}
+
+

--- a/grafana/dashboards/Sensor Overview.json
+++ b/grafana/dashboards/Sensor Overview.json
@@ -1,0 +1,181 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "uid": "sensor-overview",
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Temperature (°C)",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sensor_temperature_celsius",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 35 },
+              { "color": "red", "value": 40 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Humidity (%)",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sensor_humidity_percent",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 70 },
+              { "color": "red", "value": 85 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Temperature over time",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 6 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sensor_temperature_celsius",
+          "legendFormat": "Temperature",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "celsius" },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Humidity over time",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sensor_humidity_percent",
+          "legendFormat": "Humidity",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "percent" },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "list", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Last successful read",
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 22 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "Prometheus" },
+          "expr": "sensor_last_read_success_unix",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "s" },
+        "overrides": []
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Reads & Errors",
+      "gridPos": { "h": 4, "w": 16, "x": 8, "y": 22 },
+      "targets": [
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "increase(sensor_reads_total[5m])", "refId": "A" },
+        { "datasource": { "type": "prometheus", "uid": "Prometheus" }, "expr": "increase(sensor_read_errors_total[5m])", "refId": "B" }
+      ],
+      "options": {
+        "displayMode": "gradient"
+      }
+    }
+  ],
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["sensors"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sensor Overview",
+  "version": 1
+}
+
+

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: true
+

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'sensors'
+    static_configs:
+      - targets: ['host.docker.internal:5001']
+        labels:
+          service: 'sensor-web-endpoint'
+

--- a/sensors/requirements.txt
+++ b/sensors/requirements.txt
@@ -2,3 +2,4 @@ pyserial==3.5
 firebase-admin==7.1.0
 python-dotenv==1.0.0
 flask==3.0.0
+prometheus-client==0.20.0


### PR DESCRIPTION
This pull request introduces a full observability stack for the sensor system, adding Prometheus and Grafana for monitoring, and integrates live sensor metrics into the frontend dashboard. It adds Prometheus metrics export to the Flask web endpoint, provides Docker Compose setup for local observability, and embeds a Grafana dashboard into the Next.js frontend. Documentation is updated to cover the new stack and usage.

**Observability & Monitoring Integration**

* Added Prometheus metrics export to `sensors/web_endpoint.py`, including metrics for temperature, humidity, read counts, error counts, last read timestamp, and Firebase writes. Introduced a `/metrics` endpoint and background sampler thread for periodic metric updates.
* Added `prometheus-client` to `sensors/requirements.txt` to support metrics export.
* Added Prometheus scrape configuration in `prometheus/prometheus.yml` to collect metrics from the sensor web endpoint.

**Grafana Dashboard & Provisioning**

* Added a pre-configured Grafana dashboard (`grafana/dashboards/Sensor Overview.json`) visualizing sensor metrics, including temperature, humidity, last read, and error counters.
* Added Grafana provisioning for dashboards and Prometheus datasource (`grafana/provisioning/dashboards/dashboards.yml`, `grafana/provisioning/datasources/datasource.yml`).

**Local Development Stack**

* Added `docker-compose.yml` to spin up Prometheus and Grafana locally, with proper volume mounts and configuration for scraping and dashboard provisioning.

**Frontend Integration**

* Added a reusable `GrafanaEmbed` React component to embed Grafana dashboards in the Next.js frontend (`frontend/src/components/widgets/GrafanaEmbed.tsx`).
* Updated the dashboard page to use `GrafanaEmbed` in place of the previous overview map, allowing live visualization of sensor data. 
