### PR TITLE
Refactor reports API to fetch data from Firestore

### DIFF
--- a/frontend/src/app/api/data/reports/route.ts
+++ b/frontend/src/app/api/data/reports/route.ts
@@ -1,36 +1,52 @@
 import { NextRequest, NextResponse } from "next/server";
 import { AUTH_COOKIE_NAME, verifyUserJwt } from "@/lib/jwt";
-
-const regions = [
-  "Assam",
-  "Meghalaya",
-  "Manipur",
-  "Mizoram",
-  "Tripura",
-  "Nagaland",
-  "Arunachal Pradesh",
-  "Sikkim",
-];
+import { getReportsCollection, convertTimestamp } from "@/lib/firestore";
 
 export async function GET(req: NextRequest) {
   const token = req.cookies.get(AUTH_COOKIE_NAME)?.value;
   if (!token) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  
   try {
     await verifyUserJwt(token);
   } catch {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const items = Array.from({ length: 24 }).map((_, i) => ({
-    id: `RPT-${(1000 + i).toString()}`,
-    title: ["Suspected cholera", "Diarrheal cases", "Contaminated source", "IoT sensor anomaly"][i % 4],
-    district: ["Kamrup", "Tinsukia", "East Khasi Hills", "Imphal West", "Aizawl", "West Tripura"][i % 6],
-    region: regions[i % regions.length],
-    type: ["outbreak", "report", "sensor"][i % 3],
-    time: Date.now() - i * 60 * 60 * 1000,
-  }));
+  try {
+    const reportsCollection = getReportsCollection();
+    const snapshot = await reportsCollection
+      .limit(50)
+      .get();
 
-  return NextResponse.json({ items, ts: Date.now() }, { headers: { "Cache-Control": "no-store" } });
+    const items = snapshot.docs.map((doc) => {
+      const data = doc.data();
+      const now = Date.now();
+      
+      return {
+        id: doc.id,
+        title: data.symptoms || "Health Report",
+        region: data.location || "Unknown Location",
+        district: data.location || "Unknown District",
+        type: "health_report",
+        time: data.createdAt ? convertTimestamp(data.createdAt).getTime() : now,
+        // Include additional Firestore data
+        age: data.age,
+        userID: data.userID,
+        waterID: data.waterID,
+        symptoms: data.symptoms,
+        location: data.location,
+        createdAt: data.createdAt ? convertTimestamp(data.createdAt) : new Date(now),
+      };
+    });
+
+    return NextResponse.json({ items, ts: Date.now() }, { headers: { "Cache-Control": "no-store" } });
+  } catch (error) {
+    console.error("Error fetching reports from Firestore:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch reports" },
+      { status: 500 }
+    );
+  }
 }
 
 

--- a/frontend/src/components/dashboard/ReportsList.tsx
+++ b/frontend/src/components/dashboard/ReportsList.tsx
@@ -12,7 +12,7 @@ export default function ReportsList({
   regionFilter: string;
   query: string;
 }) {
-  const { data } = useSWR("/api/data/reports", fetcher, {
+  const { data, error } = useSWR("/api/data/reports", fetcher, {
     refreshInterval: 30_000,
   });
   const items = useMemo(() => {
@@ -23,38 +23,65 @@ export default function ReportsList({
       district: string;
       type: string;
       time: number;
+      age?: number;
+      userID?: string;
+      waterID?: string;
+      symptoms?: string;
+      location?: string;
+      createdAt?: Date;
     }>;
+
     return all.filter(
       (it) =>
         (regionFilter === "All Regions" || it.region === regionFilter) &&
         (!query ||
           it.title.toLowerCase().includes(query.toLowerCase()) ||
-          it.district.toLowerCase().includes(query.toLowerCase()))
+          it.district.toLowerCase().includes(query.toLowerCase()) ||
+          it.symptoms?.toLowerCase().includes(query.toLowerCase()) ||
+          it.location?.toLowerCase().includes(query.toLowerCase()))
     );
   }, [data, regionFilter, query]);
 
   return (
     <div className="rounded-2xl bg-white/70 dark:bg-white/5 backdrop-blur border border-slate-200/60 dark:border-white/10 shadow-sm">
       <div className="p-4 border-b border-slate-200/60 dark:border-white/10">
-        <h3 className="text-sm font-medium">Recent Field Reports</h3>
+        <h3 className="text-sm font-medium">Health Reports</h3>
+        {error && (
+          <div className="mt-2 p-2 bg-red-100 border border-red-300 rounded text-red-700 text-xs">
+            API Error: {error.message || "Failed to fetch reports"}
+          </div>
+        )}
       </div>
       <ul className="divide-y divide-slate-200/60 dark:divide-white/10">
         {items.map((it) => (
-          <li key={it.id} className="p-4 flex items-center justify-between">
-            <div>
-              <div className="text-sm font-medium">{it.title}</div>
-              <div className="text-xs text-slate-500 dark:text-slate-400">
-                {it.district}, {it.region}
+          <li key={it.id} className="p-4">
+            <div className="flex items-start justify-between">
+              <div className="flex-1">
+                <div className="text-sm font-medium text-slate-900 dark:text-white">
+                  {it.symptoms || it.title}
+                </div>
+                <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+                  📍 {it.location || it.region}
+                </div>
+                <div className="flex items-center gap-4 mt-2 text-xs text-slate-500 dark:text-slate-400">
+                  {it.age && <span>👤 Age: {it.age}</span>}
+                  {it.userID && <span>🆔 User: {it.userID}</span>}
+                  {it.waterID && <span>💧 Water: {it.waterID}</span>}
+                </div>
               </div>
-            </div>
-            <div className="text-xs text-slate-500 dark:text-slate-400">
-              {new Date(it.time).toLocaleString()}
+              <div className="text-xs text-slate-500 dark:text-slate-400 ml-4">
+                {new Date(it.time).toLocaleString()}
+              </div>
             </div>
           </li>
         ))}
         {items.length === 0 && (
-          <li className="p-6 text-sm text-slate-500 dark:text-slate-400">
-            No reports match current filters.
+          <li className="p-6 text-sm text-slate-500 dark:text-slate-400 text-center">
+            <div className="text-4xl mb-2">📋</div>
+            <div>No health reports found</div>
+            <div className="text-xs mt-1">
+              Try adjusting your filters or check back later
+            </div>
           </li>
         )}
       </ul>

--- a/frontend/src/lib/firestore.ts
+++ b/frontend/src/lib/firestore.ts
@@ -46,6 +46,11 @@ export function getUsersCollection() {
   return firestore.collection('users');
 }
 
+export function getReportsCollection() {
+  const firestore = initializeFirestore();
+  return firestore.collection('reports');
+}
+
 export function getMessagingClient(): Messaging {
   if (!msg) {
     // Ensure app and clients are initialized


### PR DESCRIPTION
This pull request updates the health reports feature to fetch real data from Firestore instead of using mock data. It also improves the user interface and error handling for the reports list. The most important changes are grouped below:

**Backend Integration and Data Fetching:**
* The API endpoint in `route.ts` now fetches up to 50 health reports from Firestore using the new `getReportsCollection` helper, replacing the previous mock data. Additional fields from Firestore (such as `age`, `userID`, `waterID`, `symptoms`, and `location`) are now included in the response. Robust error handling was added for Firestore fetch failures. 

**Reports List UI and Filtering Enhancements:**
* The reports list in `ReportsList.tsx` now displays more detailed information for each report, including symptoms, location, age, user ID, and water ID. Filtering was improved to include symptoms and location in addition to title and district.
* The UI was updated to show a clearer empty state with suggestions when no reports match the filters, and the section title was changed to "Health Reports."
* API errors are now surfaced in the UI, displaying a user-friendly error message if fetching reports fails.

**Supporting Firestore Helper:**
* Added a helper function `getReportsCollection` in `firestore.ts` to simplify access to the reports collection in Firestore.